### PR TITLE
Support for re-type the shortcut in MACShortcutView

### DIFF
--- a/Framework/MASHotKey.h
+++ b/Framework/MASHotKey.h
@@ -8,5 +8,7 @@ extern FourCharCode const MASHotKeySignature;
 @property(copy) dispatch_block_t action;
 
 + (instancetype) registeredHotKeyWithShortcut: (MASShortcut*) shortcut;
+- (BOOL) activate;
+- (void) deactivate;
 
 @end

--- a/Framework/MASShortcutMonitor.h
+++ b/Framework/MASShortcutMonitor.h
@@ -24,4 +24,6 @@
 - (void) unregisterShortcut: (MASShortcut*) shortcut;
 - (void) unregisterAllShortcuts;
 
+- (void) setShortcut: (MASShortcut*) shortcut active: (BOOL) active;
+
 @end

--- a/Framework/MASShortcutMonitor.m
+++ b/Framework/MASShortcutMonitor.m
@@ -74,6 +74,12 @@ static OSStatus MASCarbonEventCallback(EventHandlerCallRef, EventRef, void*);
     return !![_hotKeys objectForKey:shortcut];
 }
 
+- (void) setShortcut: (MASShortcut*) shortcut active: (BOOL) active
+{
+    MASHotKey *hotKey = [_hotKeys objectForKey:shortcut];
+    active ? [hotKey activate] : [hotKey deactivate];
+}
+
 #pragma mark Event Handling
 
 - (void) handleEvent: (EventRef) event

--- a/Framework/MASShortcutView.m
+++ b/Framework/MASShortcutView.m
@@ -1,5 +1,6 @@
 #import "MASShortcutView.h"
 #import "MASShortcutValidator.h"
+#import "MASShortcutMonitor.h"
 #import "MASLocalization.h"
 
 NSString *const MASShortcutBinding = @"shortcutValue";
@@ -136,6 +137,7 @@ static const CGFloat MASButtonFontSize = 11;
     [self activateEventMonitoring:_recording];
     [self activateResignObserver:_recording];
     [self setNeedsDisplay:YES];
+    [[MASShortcutMonitor sharedMonitor] setShortcut:[self shortcutValue] active:!flag];
 
     // Give VoiceOver users feedback on the result. Requires at least 10.9 to run.
     // We’re silencing the “tautological compare” warning here so that if someone


### PR DESCRIPTION
When MASShortcutView starts the recording, a shortcut it currently holding will be temporarily deactivated to allow the user to type the same shortcut